### PR TITLE
add migrateResponses functionality

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -278,7 +278,7 @@ exports.reportedPostsCreate = functions.region('europe-west1').firestore.documen
     }
   });
 
-  exports.solvedPostsCreate = functions.region('europe-west1').firestore.document('/deleted/{reportRequestId}')
+  exports.deletedCreate = functions.region('europe-west1').firestore.document('/deleted/{reportRequestId}')
   .onCreate(async (snap, context) => {
     try {
       const db = admin.firestore();

--- a/functions/index.js
+++ b/functions/index.js
@@ -300,10 +300,10 @@ exports.reportedPostsCreate = functions.region('europe-west1').firestore.documen
   }
 
   async function migrateResponses(db, collectionToMigrateFrom, documentId, collectionToMigrateTo) {
-    const responsesSnap = db.collection(collectionToMigrateFrom).doc(documentId).collection('offer-help').get();
+    const responsesSnap = await db.collection(collectionToMigrateFrom).doc(documentId).collection('offer-help').get();
     const responses = responsesSnap.docs.map((docSnapshot) => ({ ...docSnapshot.data(), id: docSnapshot.id }));
 
-    const batch = fb.store.batch();
+    const batch = db.batch();
     const subCollection = db.collection(collectionToMigrateTo).doc(documentId).collection('offer-help');
     responses.map((response) => batch.set(subCollection.doc(response.id), response));
     await batch.commit();

--- a/functions/index.js
+++ b/functions/index.js
@@ -261,7 +261,7 @@ exports.reportedPostsCreate = functions.region('europe-west1').firestore.documen
   .onCreate(async (snap, context) => {
     try {
       const db = admin.firestore();
-      const askForHelpCollectionName = 'ask-for-help'
+      const askForHelpCollectionName = 'ask-for-help';
       const snapValue = snap.data();
       const { uid } = snapValue;
       const askForHelpSnap = await db.collection(askForHelpCollectionName).doc(snap.id).get();

--- a/functions/index.js
+++ b/functions/index.js
@@ -267,7 +267,7 @@ exports.reportedPostsCreate = functions.region('europe-west1').firestore.documen
 
       if (!userIdsMatch(db, askForHelpCollectionName, snap.id, uid)) return;
 
-      await migrateResponses(askForHelpCollectionName, snap.id, 'solved-posts');
+      await migrateResponses(db, askForHelpCollectionName, snap.id, 'solved-posts');
       await db.collection(askForHelpCollectionName).doc(snap.id).delete();
     } catch (e) {
       console.error(e);
@@ -280,12 +280,12 @@ exports.reportedPostsCreate = functions.region('europe-west1').firestore.documen
     try {
       const db = admin.firestore();
       const snapValue = snap.data();
-      const { uid, collectionName } = snapValue; // collectionName can be either "ask-for-help" or "solved-posts"
+      const { uid, collectionName, askForHelpId } = snapValue; // collectionName can be either "ask-for-help" or "solved-posts"
 
-      if (!userIdsMatch(db, collectionName, snap.id, uid)) return;
+      if (!userIdsMatch(db, collectionName, askForHelpId, uid)) return;
 
-      await migrateResponses(collectionName, snap.id, 'deleted');
-      await db.collection(collectionName).doc(snap.id).delete();
+      await migrateResponses(db, collectionName, askForHelpId, 'deleted');
+      await db.collection(collectionName).doc(askForHelpId).delete();
     } catch (e) {
       console.error(e);
       console.log('ID', snap.id);


### PR DESCRIPTION
* adds migration of responses from the` ask-for-help` collection on `solvedPostsCreate`
* adds migration of responses on delete for the collection that the document is deleted from (`ask-for-help` or `solved-posts`) to the `deleted` collection
* as a normal `delete` on a document does not delete its subcollections, a recursive delete needs to be performed on that subcollection
 * unfortunately, `firebase-admin` does [not have an API](https://github.com/firebase/firebase-admin-node/issues/361) call for this (yet) --> they recommend to add [this code snippet](https://firebase.google.com/docs/firestore/manage-data/delete-data#collections)